### PR TITLE
商品画像プレビュー機能の実装

### DIFF
--- a/app/assets/stylesheets/image.css
+++ b/app/assets/stylesheets/image.css
@@ -1,0 +1,6 @@
+img {
+  height: 100px;
+  width: 100px;
+  /* 縦横比を保ったまま、画像を縦横100pxのサイズに収めるプロパティです */
+  object-fit: contain;
+}

--- a/app/assets/stylesheets/preview.css
+++ b/app/assets/stylesheets/preview.css
@@ -1,0 +1,7 @@
+#previews {
+  display: flex;
+}
+
+.preview {
+  margin-right: 30px;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/activestorage").start()
 require("channels")
 require("../charge");
 require("../card");
+require("../preview");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function (){
+  const postForm = document.getElementsByClassName('items-sell-main');
+  const previewList = document.getElementById('previews');
+  if (!postForm) return null;
+  
+
+  const fileField = document.querySelector('input[type="file"][name="item[image]"]');
+  fileField.addEventListener('change', function(e){
+    const alreadyPreview  = document.querySelector('.preview');
+    if (alreadyPreview){
+      alreadyPreview.remove();
+    };
+    
+    const file = e.target.files[0];
+    const blob = window.URL.createObjectURL(file);
+    
+    const previewWrapper = document.createElement('div');
+    previewWrapper.setAttribute('class', 'preview');
+
+    const previewImage = document.createElement('img');
+    previewImage.setAttribute('class', 'preview-image');
+    previewImage.setAttribute('src', blob);
+
+    previewWrapper.appendChild(previewImage);
+    previewList.appendChild(previewWrapper);
+  });
+});

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -21,6 +21,7 @@ app/assets/stylesheets/items/new.css %>
           <p>
             クリックしてファイルをアップロード
           </p>
+          <div id="previews"></div>
           <%= f.file_field :image, id:"item-image" %>
         </div>
       </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -19,6 +19,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
+        <div id="previews"></div>
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>


### PR DESCRIPTION
# What
　商品画像プレビュー機能の実装
　商品出品・商品情報編集画面において、画像を選択するとプレビュー表示される。
# Why
　ユーザーが商品出品・商品情報編集を行う際、正しい画像が選択されているかわかりやすくするため。