### PR TITLE
複数枚の画像投稿・プレビュー表示機能の実装

### DIFF
--- a/app/assets/stylesheets/image.css
+++ b/app/assets/stylesheets/image.css
@@ -4,3 +4,16 @@ img {
   /* 縦横比を保ったまま、画像を縦横100pxのサイズに収めるプロパティです */
   object-fit: contain;
 }
+
+.other-images {
+  display: flex;
+}
+
+.other-image {
+  margin-right: 10px;
+}
+
+.main-image {
+  height: 200px;
+  width: 200px;
+}

--- a/app/assets/stylesheets/preview.css
+++ b/app/assets/stylesheets/preview.css
@@ -5,3 +5,10 @@
 .preview {
   margin-right: 30px;
 }
+
+.image-delete-button {
+  text-align: center;
+  border: solid 1px;
+  cursor: pointer;
+  margin-bottom: 5px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,7 +45,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:image, :name, :text, :category_id, :condition_id, :delivery_charge_id, :prefecture_id, :delivery_day_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :category_id, :condition_id, :delivery_charge_id, :prefecture_id, :delivery_day_id, :price, {images: []}).merge(user_id: current_user.id)
   end
 
   def set_params

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,27 +1,105 @@
 document.addEventListener('DOMContentLoaded', function (){
+  // 新規投稿・編集ページのフォーム取得
   const postForm = document.getElementsByClassName('items-sell-main');
+  // プレビュー表示のためのスペースを取得
   const previewList = document.getElementById('previews');
+  // 新規投稿・編集ページのフォームがなければここで処理が終了
   if (!postForm) return null;
+  // 画像投稿枚数の制限を定義
+  const imageLimits = 5;
   
-
-  const fileField = document.querySelector('input[type="file"][name="item[image]"]');
-  fileField.addEventListener('change', function(e){
-    const alreadyPreview  = document.querySelector('.preview');
-    if (alreadyPreview){
-      alreadyPreview.remove();
-    };
-    
-    const file = e.target.files[0];
-    const blob = window.URL.createObjectURL(file);
-    
+  // プレビュー画像を生成・表示する関数
+  const buildPreviewImage = (dataIndex, blob) => {
+    // 画像表示のためのdiv要素を生成
     const previewWrapper = document.createElement('div');
     previewWrapper.setAttribute('class', 'preview');
+    previewWrapper.setAttribute('data-index', dataIndex);
 
+    // 表示する画像を生成
     const previewImage = document.createElement('img');
     previewImage.setAttribute('class', 'preview-image');
     previewImage.setAttribute('src', blob);
 
+    // 削除ボタンを生成
+    const deleteButton = document.createElement('div');
+    deleteButton.setAttribute("class", "image-delete-button");
+    deleteButton.innerText = "削除";
+
+    // 削除ボタンをクリックしたらプレビューとfile_fieldを削除
+    deleteButton.addEventListener('click', () => deleteImage(dataIndex));
+
+    // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
+    previewWrapper.appendChild(deleteButton);
     previewList.appendChild(previewWrapper);
-  });
+  };
+
+  // file_fieldを生成・表示する関数
+  const buildNewFileField = () => {
+    // ２枚目用のfile_fieldを作成
+    const newFileField = document.createElement('input');
+    newFileField.setAttribute('type', 'file');
+    newFileField.setAttribute('name', 'item[images][]');
+
+    // 最後のfile_fieldを取得
+    const lastFileField = document.querySelector('input[type="file"][name="item[images][]"]:last-child');
+    const nextDataIndex = Number(lastFileField.getAttribute('data-index'))+1;
+    newFileField.setAttribute('data-index', nextDataIndex);
+
+    // 追加されたfile_fieldにchangeイベントをセット
+    newFileField.addEventListener('change', changedFileField);
+
+    // 生成したfile_fieldを表示
+    const fileFieldsArea = document.querySelector('.click-upload');
+    fileFieldsArea.appendChild(newFileField);
+  };
+
+  // 指定したdata-indexを持つプレビューとfile_fieldを削除
+  const deleteImage = (dataIndex) => {
+    const deletePreviewImage = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+    deletePreviewImage.remove();
+    const deleteFileField = document.querySelector(`input[type="file"][data-index="${dataIndex}"]`);
+    deleteFileField.remove();
+
+    // 画像の枚数が最大の時に削除ボタンを押した場合、file_fieldを１つ追加
+    const imageCount = document.querySelectorAll(".preview").length;
+    if (imageCount == imageLimits - 1) buildNewFileField();
+  };
+
+  // input要素で値の変化が起きた時に呼び出される関数の中身
+  const changedFileField = (e) => {
+    // data-index（何番目を操作しているのか）を取得
+    const dataIndex = e.target.getAttribute('data-index');
+
+    const file = e.target.files[0];
+
+    // fileが空＝何も選択しなかった　ということなのでプレビュー等を削除して終了
+    if (!file){
+      deleteImage(dataIndex);
+      return null;
+    };
+
+    const blob = window.URL.createObjectURL(file);
+
+    // data-indexを利用し、すでにプレビューが表示されているか確認
+    const alreadyPreview = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+    if (alreadyPreview){
+      // クリックしたfile_fieldのdata-indexと同じ番号のプレビュー画像がすでに表示されている場合は、画像の差し替えのみ実施
+      const alreadyPreviewImage = alreadyPreview.querySelector('img');
+      alreadyPreviewImage.setAttribute("src", blob);
+      return null;
+    };
+
+    buildPreviewImage(dataIndex, blob);
+
+    // 画像の枚数制限を超えなければ、新しいfile_fieldを追加
+    const imageCount = document.querySelectorAll(".preview").length;
+    if (imageCount < imageLimits) buildNewFileField();
+  };
+
+  // input要素を取得
+  const fileField = document.querySelector('input[type="file"][name="item[images][]"]');
+
+  // input要素で値の変化が起きた時に呼び出される関数
+  fileField.addEventListener('change', changedFileField);
 });

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  validates :image,              presence: true
+  validates :images,             length: {minimum: 1, maximum: 5}
   validates :name,               presence: true, length:{ maximum: 40 }
   validates :text,               presence: true, length:{ maximum: 1000 }
   validates :category_id,        presence: true, numericality: {other_than: 1}
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   validates :delivery_day_id,    presence: true, numericality: {other_than: 1}
   validates :price,              presence: true, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
   
-  has_one_attached :image
+  has_many_attached :images
   belongs_to :user
   has_one :order
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
             クリックしてファイルをアップロード
           </p>
           <div id="previews"></div>
-          <%= f.file_field :image, id:"item-image" %>
+          <%= f.file_field :images, name: 'item[images][]', data: {index: 0}, id:"item-image" %>
         </div>
       </div>
       <%# /商品画像 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
         <li class='list'>
           <%= link_to item_path(item.id), method: :get do %>
             <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
+              <%= image_tag item.images[0], class: "item-img" %>
 
               <% if item.order != nil %>
                 <div class='sold-out'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,7 @@
           クリックしてファイルをアップロード
         </p>
         <div id="previews"></div>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, name: 'item[images][]',data: {index: 0}, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,14 @@
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%= image_tag @item.images[0] ,class:"item-box-img" %><br>
+        <div class="other-images">
+          <% @item.images[1..-1].each do |image| %>
+            <div class="other-image">
+              <%= image_tag image %>
+            </div>
+          <% end %>
+        </div>
       <% if @item.order != nil %>
         <div class="sold-out">
           <span>Sold Out!!</span>


### PR DESCRIPTION
# What
　商品出品・商品情報編集ページにおける複数枚の画像投稿機能・プレビュー表示機能の実装
# Why
　ユーザーが商品購入の際、商品の情報をより詳細に把握できるよう、１つの商品における複数枚の画像投稿機能が必要であるため。